### PR TITLE
add: document using spring openapi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,12 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>2.5.0</version>
+			<version>3.0.1</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 	</dependencies>
 
@@ -102,6 +107,20 @@
 						<path>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.14.1</version>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>${lombok.version}</version>
 						</path>
 					</annotationProcessorPaths>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,27 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,12 @@
             <artifactId>lombok</artifactId>
             <optional>true</optional>
         </dependency>
+
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.5.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/example/CryptoTracking/config/RestTemplateConfiguration.java
+++ b/src/main/java/com/example/CryptoTracking/config/RestTemplateConfiguration.java
@@ -1,5 +1,8 @@
 package com.example.CryptoTracking.config;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,6 +12,16 @@ import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
+@OpenAPIDefinition(
+        info = @Info(
+                title = "Crypto Tracker API",
+                version = "1.0.0",
+                description = "API provides information about crypto currencies, fetching crypto data from CoinGecko every 5 minutes"
+        ),
+        servers = {
+                @Server(url = "http://localhost:8088/api/v1", description = "Local development server")
+        }
+)
 public class RestTemplateConfiguration {
     @Value("${coingecko.api.connect.timeout}")
     private int connectTimeout;

--- a/src/main/java/com/example/CryptoTracking/controller/CryptoController.java
+++ b/src/main/java/com/example/CryptoTracking/controller/CryptoController.java
@@ -2,6 +2,13 @@ package com.example.CryptoTracking.controller;
 
 import com.example.CryptoTracking.dto.CoinPaginationRequest;
 import com.example.CryptoTracking.dto.CoinSummaryResponse;
+import com.example.CryptoTracking.service.CoinService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -9,30 +16,47 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import com.example.CryptoTracking.service.CoinService;
 
 // Later will use MockMvc to test
 @RestController
 @RequestMapping("/api/v1/coins")
 @CrossOrigin(origins = "*")
+@Tag(name = "Coins", description = "Endpoints for retrieving and searching cryptocurrency data")
 public class CryptoController {
+
     @Autowired
     private CoinService coinService;
 
+    @Operation(
+            summary = "Get a paginated list of coins",
+            description = "Retrieves a list of cryptocurrencies. Supports filtering by price, rank, name, and pagination."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved the list of coins")
+    })
     @GetMapping
     public ResponseEntity<Page<CoinSummaryResponse>> getCoins(
-            CoinPaginationRequest coinPaginationRequest,
-            @PageableDefault(page = 0, size = 50, sort = "marketCapRank", direction = Sort.Direction.ASC)
-            Pageable pageable) {
-        Page<CoinSummaryResponse> coinSummaryResponsePage = coinService.getCoins(coinPaginationRequest, pageable);
+            @ParameterObject CoinPaginationRequest coinPaginationRequest,
+            @ParameterObject @PageableDefault(page = 0, size = 50, sort = "marketCapRank", direction = Sort.Direction.ASC) Pageable pageable) {
 
+        Page<CoinSummaryResponse> coinSummaryResponsePage = coinService.getCoins(coinPaginationRequest, pageable);
         return ResponseEntity.ok(coinSummaryResponsePage);
     }
 
+    @Operation(
+            summary = "Get coin details by ID",
+            description = "Retrieves summarized information for a specific cryptocurrency using its system identifier."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved the coin details"),
+            @ApiResponse(responseCode = "404", description = "Coin not found with the provided ID")
+    })
     @GetMapping("/{id}")
-    public ResponseEntity<CoinSummaryResponse> getCoinById(@PathVariable String id) {
-        CoinSummaryResponse coinSummaryResponse = coinService.getCoinById(id);
+    public ResponseEntity<CoinSummaryResponse> getCoinById(
+            @Parameter(description = "The unique system identifier of the coin", example = "bitcoin")
+            @PathVariable String id) {
 
+        CoinSummaryResponse coinSummaryResponse = coinService.getCoinById(id);
         return ResponseEntity.ok(coinSummaryResponse);
     }
 }

--- a/src/main/java/com/example/CryptoTracking/controller/GlobalMarketController.java
+++ b/src/main/java/com/example/CryptoTracking/controller/GlobalMarketController.java
@@ -1,7 +1,14 @@
 package com.example.CryptoTracking.controller;
 
 import com.example.CryptoTracking.dto.GlobalMarketSummaryResponse;
+import com.example.CryptoTracking.exception.ErrorResponse;
 import com.example.CryptoTracking.service.GlobalMarketService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -12,10 +19,22 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/global")
 @CrossOrigin(origins = "*")
+@Tag(name = "Global Market", description = "Endpoints for retrieving overall global cryptocurrency market data")
 public class GlobalMarketController {
+
     @Autowired
     private GlobalMarketService globalMarketService;
 
+    @Operation(
+            summary = "Get global market summary",
+            description = "Fetches a summarized view of the global cryptocurrency market including total market cap, 24h volume, and active coin count."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved the global market data"),
+
+            @ApiResponse(responseCode = "500", description = "Internal server error while fetching data from third-party API",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @GetMapping
     public ResponseEntity<GlobalMarketSummaryResponse> getGlobalMarketData() {
         GlobalMarketSummaryResponse data = globalMarketService.getGlobalMarket();

--- a/src/main/java/com/example/CryptoTracking/dto/CoinGeckoResponse.java
+++ b/src/main/java/com/example/CryptoTracking/dto/CoinGeckoResponse.java
@@ -2,6 +2,7 @@ package com.example.CryptoTracking.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.math.BigDecimal;
@@ -15,46 +16,62 @@ Can use JsonTest for testing
 
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Schema(description = "DTO containing detailed coin market data fetched from CoinGecko API")
 public class CoinGeckoResponse {
+
+    @Schema(description = "System identifier of the coin", example = "bitcoin")
     @JsonProperty("id")
     private String id;
 
+    @Schema(description = "Symbol of the coin", example = "btc")
     @JsonProperty("symbol")
     private String symbol;
 
+    @Schema(description = "Display name of the coin", example = "Bitcoin")
     @JsonProperty("name")
     private String name;
 
+    @Schema(description = "Timestamp of the last data update", example = "2024-05-12T10:00:00Z")
     @JsonProperty("last_updated")
     private Instant lastUpdated;
 
+    @Schema(description = "URL of the coin's logo image in large size", example = "https://assets.coingecko.com/coins/images/1/large/bitcoin.png")
     @JsonProperty("image")
     private String image;
 
+    @Schema(description = "Current price of the coin in the configured fiat currency or USD", example = "65432.10")
     @JsonProperty("current_price")
     private BigDecimal currentPrice;
 
+    @Schema(description = "Total market capitalization", example = "1285000000000")
     @JsonProperty("market_cap")
     private Long marketCap;
 
+    @Schema(description = "Market capitalization rank on CoinGecko", example = "1")
     @JsonProperty("market_cap_rank")
     private Integer marketCapRank;
 
+    @Schema(description = "Total trading volume in the last 24 hours", example = "35000000000.50")
     @JsonProperty("total_volume")
     private BigDecimal totalVolume;
 
+    @Schema(description = "Highest price reached in the last 24 hours", example = "66000.00")
     @JsonProperty("high_24h")
     private BigDecimal high24h;
 
+    @Schema(description = "Lowest price reached in the last 24 hours", example = "64200.50")
     @JsonProperty("low_24h")
     private BigDecimal low24h;
 
+    @Schema(description = "Price change percentage in the last 24 hours", example = "2.35")
     @JsonProperty("price_change_percentage_24h")
     private Double priceChangePercentage24h;
 
+    @Schema(description = "Price change percentage in the last 7 days", example = "-1.42")
     @JsonProperty("price_change_percentage_7d_in_currency")
     private Double priceChangePercentage7d;
 
+    @Schema(description = "Price change percentage in the last 1 hour", example = "0.15")
     @JsonProperty("price_change_percentage_1h_in_currency")
     private Double priceChangePercentage1h;
 }

--- a/src/main/java/com/example/CryptoTracking/dto/CoinPaginationRequest.java
+++ b/src/main/java/com/example/CryptoTracking/dto/CoinPaginationRequest.java
@@ -1,5 +1,6 @@
 package com.example.CryptoTracking.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.math.BigDecimal;
@@ -10,11 +11,24 @@ However, this approach is only used because there are not many criteria in Coins
  */
 
 @Data
+@Schema(description = "Request object for filtering and paginating cryptocurrency data")
 public class CoinPaginationRequest {
+
+    @Schema(description = "Filter by specific coin system ID", example = "bitcoin")
     private String id;
+
+    @Schema(description = "Filter by coin display name", example = "Bitcoin")
     private String name;
+
+    @Schema(description = "Minimum current price threshold in USD", example = "50000.00")
     private BigDecimal minPrice;
+
+    @Schema(description = "Maximum current price threshold in USD", example = "75000.00")
     private BigDecimal maxPrice;
+
+    @Schema(description = "Highest market cap rank to filter", example = "1")
     private Integer minMarketCapRank;
+
+    @Schema(description = "Lowest market cap rank to filter", example = "100")
     private Integer maxMarketCapRank;
 }

--- a/src/main/java/com/example/CryptoTracking/dto/CoinSummaryResponse.java
+++ b/src/main/java/com/example/CryptoTracking/dto/CoinSummaryResponse.java
@@ -1,5 +1,6 @@
 package com.example.CryptoTracking.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
@@ -7,11 +8,24 @@ import java.math.BigDecimal;
 
 @Data
 @Builder
+@Schema(description = "Summary response object containing essential cryptocurrency details, designed to minimize payload size and hide internal data")
 public class CoinSummaryResponse {
+
+    @Schema(description = "Cryptocurrency symbol", example = "btc")
     private String symbol;
+
+    @Schema(description = "Display name of the cryptocurrency", example = "Bitcoin")
     private String name;
+
+    @Schema(description = "URL to the cryptocurrency's logo image", example = "https://assets.coingecko.com/coins/images/1/large/bitcoin.png")
     private String image;
+
+    @Schema(description = "Current market price in fiat currency or in USD", example = "65432.10")
     private BigDecimal price;
+
+    @Schema(description = "Current rank based on market capitalization", example = "1")
     private Integer marketCapRank;
+
+    @Schema(description = "Percentage change in price over the last 24 hours", example = "2.35")
     private Double priceChangePercentage24h;
 }

--- a/src/main/java/com/example/CryptoTracking/dto/GlobalDataResponse.java
+++ b/src/main/java/com/example/CryptoTracking/dto/GlobalDataResponse.java
@@ -1,6 +1,7 @@
 package com.example.CryptoTracking.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.math.BigDecimal;
@@ -12,30 +13,42 @@ Provides every information you need for every markets available
 */
 
 @Data
+@Schema(description = "Wrapper object containing global cryptocurrency market data fetched from CoinGecko's /global endpoint")
 public class GlobalDataResponse {
+
+    @Schema(description = "The core data object containing all global metrics")
     @JsonProperty("data")
     private DataObj data;
 
     @Data
-    public static class DataObj{
+    @Schema(description = "Detailed global market metrics including active coins, total volume, and market dominance")
+    public static class DataObj {
+
+        @Schema(description = "Total number of active cryptocurrencies currently being tracked", example = "13254")
         @JsonProperty("active_cryptocurrencies")
         private Integer activeCryptocurrencies;
 
+        @Schema(description = "Total number of active cryptocurrency exchanges", example = "982")
         @JsonProperty("markets")
         private Integer markets;
 
+        @Schema(description = "Total market capitalization mapped by currency symbol", example = "{\"usd\": 2500000000000.50, \"btc\": 45000000.0}")
         @JsonProperty("total_market_cap")
         private Map<String, BigDecimal> totalMarketCap;
 
+        @Schema(description = "Total trading volume in the last 24 hours mapped by currency symbol", example = "{\"usd\": 125000000000.00}")
         @JsonProperty("total_volume")
         private Map<String, BigDecimal> totalVolume;
 
+        @Schema(description = "Global market cap change percentage in USD over the last 24 hours", example = "1.52")
         @JsonProperty("market_cap_change_percentage_24h_usd")
         private Double marketCapChangePercentage24hUsd;
 
+        @Schema(description = "Market dominance percentage of top cryptocurrencies", example = "{\"btc\": 51.2, \"eth\": 16.8}")
         @JsonProperty("market_cap_percentage")
         private Map<String, Double> marketCapPercentage;
 
+        @Schema(description = "Unix timestamp of the last data update", example = "1708147200")
         @JsonProperty("updated_at")
         private Long updatedAt;
     }

--- a/src/main/java/com/example/CryptoTracking/dto/GlobalMarketSummaryResponse.java
+++ b/src/main/java/com/example/CryptoTracking/dto/GlobalMarketSummaryResponse.java
@@ -1,5 +1,6 @@
 package com.example.CryptoTracking.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
@@ -7,9 +8,18 @@ import java.math.BigDecimal;
 
 @Data
 @Builder
-public class GlobalMarketSummaryResponse{
+@Schema(description = "Summary response object containing key global cryptocurrency market metrics. Designed to expose only necessary aggregated data to the client.")
+public class GlobalMarketSummaryResponse {
+
+    @Schema(description = "Total number of active cryptocurrencies currently being tracked", example = "13254")
     private Integer activeCryptocurrencies;
+
+    @Schema(description = "Total number of active cryptocurrency exchanges or markets", example = "982")
     private Integer markets;
+
+    @Schema(description = "Total global market capitalization in fiat currency or in USD", example = "2500000000000.50")
     private BigDecimal totalMarketCap;
+
+    @Schema(description = "Total global trading volume across all markets in the last 24 hours", example = "125000000000.00")
     private BigDecimal totalVolume;
 }

--- a/src/main/java/com/example/CryptoTracking/scheduler/DataFetchScheduler.java
+++ b/src/main/java/com/example/CryptoTracking/scheduler/DataFetchScheduler.java
@@ -1,11 +1,13 @@
 package com.example.CryptoTracking.scheduler;
 
 import com.example.CryptoTracking.service.GlobalMarketService;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import com.example.CryptoTracking.service.CoinService;
 
+@Slf4j
 @Component
 public class DataFetchScheduler {
     @Autowired
@@ -19,9 +21,10 @@ public class DataFetchScheduler {
     public void fetchAndStore() {
         try {
             coinService.fetchCoinsFromAPI();
+
             globalMarketService.fetchGlobalMarketsFromAPI();
         } catch (Exception e) {
-            System.err.println("Scheduled fetch failed: " + e.getMessage());
+            log.error("Scheduler failed: ", e);
         }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,3 +18,9 @@ server.port=8088
 coingecko.api.connect.timeout=3000
 coingecko.api.read.timeout=5000
 coingecko.api.key=${COINGECKO_API_KEY}
+
+# Spring doc OpenAPI url
+# Backend parse JSON
+springdoc.api-docs.path=/api/v1/docs
+# Frontend fetch data
+springdoc.swagger-ui.url=/api/v1/docs


### PR DESCRIPTION
**Reason:** Document for comprehension, easier maintenance, and providing a clear API contract for client-side integration.

**Actions:**
- Added `springdoc-openapi-starter-webmvc-ui` dependency in `pom.xml`.
- Added OpenAPI annotations (`@Tag`, `@Operation`, `@Schema`, `@ApiResponses`) for Config, DTOs, and Controllers.

**How to use:**
1. Start the Spring Boot application locally.
2. Open a web browser and navigate to the Swagger UI interface: `http://localhost:8088/swagger-ui.html`
3. You will see the interactive API dashboard. You can expand the **Global Market** or **Coins** sections to view detailed descriptions of each endpoint.
4. Click on the **"Try it out"** button inside any endpoint, input the parameters (e.g., `id`, `page`, `minPrice`), and click **"Execute"** to test the API directly from the browser.
5. Scroll down to the **"Schemas"** section at the bottom to explore the data structures of Requests, Responses, and Error payloads.